### PR TITLE
Contribution destination repo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,6 @@ SENDINBLUE_API_KEY='xkeysib-c24eea6XXXX-XXXXX'
 # NEXT_PUBLIC_MATOMO_URL=
 # NEXT_PUBLIC_MATOMO_SITE_ID=
 
-# Save service on local
-# NEXT_PUBLIC_OTA_SERVICES_PATH=
-
 # Automatically create Github issue on contribution
 GITHUB_TOKEN= #create one with repo privileges here https://github.com/settings/tokens
 GITHUB_LABEL_ADD=add

--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,4 @@ SENDINBLUE_API_KEY='xkeysib-c24eea6XXXX-XXXXX'
 
 # Automatically create Github issue on contribution
 GITHUB_TOKEN= #create one with repo privileges here https://github.com/settings/tokens
-GITHUB_REPO=OpenTermsArchive/services-all
 GITHUB_LABEL_ADD=add

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,45 @@ Although we use the MDX format which sometimes allows the instantiation of React
 
 Prefer Markdown over strings for translations, as soon as there are multiple paragraphs.
 
+## Destination repository
+
+The contribution interface can be used against any repository on which ota@opentermsarchive.org github user has issue creation rights.
+
+This repo must be passed by an url parameter called `destination`
+
+Here are some examples for contributing to different projects using
+
+- /en/contribute?destination=OpenTermsArchive/services-all
+- /en/contribute?destination=OpenTermsArchive/services-dating
+- /en/contribute?destination=ambanum/test-repo (For tests)
+- /fr/contribute?destination=ambanum/test-repo2 (For tests)
+
 ## Local creation of services from contribution interface
 
-If you are interested in setting up a local instance where you can directly save the result of the contribution interface (`/en/contribute?destination=OpenTermsArchive/services-all`) in the corresponding folder in Open Terms Archive project you have to specify where the services json files resides in the url itself:
+If you are interested in setting up a local instance where you can locally save the result of the contribution interface, you have to specify where to save it.
+This can be done with a url parameter called `localPath`.
+
+It takes a full local path string and must point to the exact folder containing the declarations.
+See below examples:
 
 ```
 /en/contribute?destination=OpenTermsArchive/services-all&localPath=/Users/username/Workspace/ambanum/OpenTermsArchive/services-all/declarations
-/en/contribute?destination=OpenTermsArchive/services-dating&localPath=/Users/username/Workspace/OpenTermsArchive/services-dating/declarations
+/en/contribute?destination=OpenTermsArchive/services-dating&localPath=/Users/username/Workspace/somewhere-else/services-dating/declarations
 ```
 
-This way, a button `Save on local` will appear on the contribution interface. By clicking on it, it will add or modify the following service declaration (as a `.json` file) in the corresponding directory.
+This way, a `Save on local` button will appear on the contribution interface. By clicking on it, it will add or modify the service declaration (saved as a `.json` file) in the corresponding directory.
+
+### Automatically generating history file
+
+As we want to ensure we can retrace the whole history of selectors we used to retrieve the corresponding documents, a history file should be created **every time you change the service declaration** (See the corresponding [decision record](./decision-record/0002-service-history.md).
+As this is a very time consuming thing to do (retrieve the last version date, format it in ISO format and pasting it in a history file), you can use a new url parameter called `versionsRepo` which will fetch the date of the last commit successfully retrieved from Github and populate the history file accordingly and automatically.
+
+**CAUTION**: You need to have a `localPath` query param (described in the previous paragraph) in the url for this to happen.
+
+```
+/en/contribute?destination=OpenTermsArchive/services-all&localPath=/Users/username/Workspace/ambanum/OpenTermsArchive/services-all/declarations&versionsRepo=ambanum/OpenTermsArchive-versions
+/en/contribute?destination=OpenTermsArchive/services-dating&localPath=/Users/username/Workspace/OpenTermsArchive/services-dating/declarations&versionsRepo=ambanum/OpenTermsArchive/versions-dating
+```
 
 ## Copywriting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,14 @@ Prefer Markdown over strings for translations, as soon as there are multiple par
 
 ## Local creation of services from contribution interface
 
-If you are interested in setting up a local instance where you can directly save the result of the contribution interface (`/contribute`) in the corresponding folder in Open Terms Archive project you have to specify where the services json files resides in the following constant in `.env` file:
+If you are interested in setting up a local instance where you can directly save the result of the contribution interface (`/en/contribute?destination=OpenTermsArchive/services-all`) in the corresponding folder in Open Terms Archive project you have to specify where the services json files resides in the url itself:
 
 ```
-NEXT_PUBLIC_OTA_SERVICES_PATH="/Users/username/Workspace/ambanum/OpenTermsArchive/services"
+/en/contribute?destination=OpenTermsArchive/services-all&localPath=/Users/username/Workspace/ambanum/OpenTermsArchive/services-all/declarations
+/en/contribute?destination=OpenTermsArchive/services-dating&localPath=/Users/username/Workspace/OpenTermsArchive/services-dating/declarations
 ```
 
-This way, a button `Save on local` will appear on the contribution interface. By clicking on it, it will add or modify the following service declaration (as a `.json` file) in the Open Terms Archive services directory.
+This way, a button `Save on local` will appear on the contribution interface. By clicking on it, it will add or modify the following service declaration (as a `.json` file) in the corresponding directory.
 
 ## Copywriting
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Default is empty
 In order for the service to automatically create issues in Github when a service is failing, you need to provide:
 
 - `GITHUB_TOKEN`: A token with repository privileges which allow access to the [GitHub API](https://github.com/settings/tokens).
-- `GITHUB_REPO`: A repository which will be used to create the issues. For example `OpenTermsArchive/services-all`
 - `GITHUB_LABEL_ADD`: The name of the label used on the repo to categorize issues corresponding to a service that needs to be added (default is `add`)
 
 **Note**: OTA.org will automatically create issues with a label defined by `GITHUB_LABEL_ADD`. **This specific label has to exist in the corresponding repository for the automatic issue creation works.**

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ In order for the service to automatically create issues in Github when a service
 
 You can easily set up analytics with [Matomo](https://matomo.org/) by providing those 2 values.
 
-### `NEXT_PUBLIC_OTA_SERVICES_PATH`
-
-This variable enables the ability to save the result of the contributing tool directly on a directory on your file system.
-
-More details on [Contributing Guide](./CONTRIBUTING#local-creation-of-services-from-contribution-interface)
-
 ### `SENDINBLUE_API_KEY`
 
 In order for users to be able to subscribe to services alerts, a mailling lists has been put in place with SendInBlue.

--- a/docker/.env.local.preproduction
+++ b/docker/.env.local.preproduction
@@ -1,7 +1,6 @@
 NEXT_PUBLIC_BASE_PATH="/preprod/open-terms-archive"
 
 # Automatically create Github issue on contribution
-GITHUB_REPO=ambanum/test-repo
 GITHUB_LABEL_ADD=add-document
 
 PORT=3000

--- a/docker/.env.local.production
+++ b/docker/.env.local.production
@@ -1,7 +1,6 @@
 NEXT_PUBLIC_BASE_PATH="/open-terms-archive"
 
 # Automatically create Github issue on contribution
-GITHUB_REPO=ambanum/test-repo
 GITHUB_LABEL_ADD=add-document
 
 PORT=3000

--- a/docker/.env.preproduction
+++ b/docker/.env.preproduction
@@ -1,7 +1,6 @@
 NEXT_PUBLIC_BASE_PATH=""
 
 # Automatically create Github issue on contribution
-GITHUB_REPO=ambanum/test-repo
 GITHUB_LABEL_ADD=add-document
 
 PORT=3000

--- a/docker/.env.production
+++ b/docker/.env.production
@@ -5,7 +5,6 @@ NEXT_PUBLIC_MATOMO_URL=https://stats.data.gouv.fr
 NEXT_PUBLIC_MATOMO_SITE_ID=179
 
 # Automatically create Github issue on contribution
-GITHUB_REPO=OpenTermsArchive/services-all
 GITHUB_LABEL_ADD=add
 
 PORT=3000

--- a/docker/.env.vagrant.preproduction
+++ b/docker/.env.vagrant.preproduction
@@ -1,5 +1,4 @@
 NEXT_PUBLIC_BASE_PATH="/preprod/open-terms-archive"
-GITHUB_REPO=ambanum/test-repo
 GITHUB_LABEL_ADD=add-document
 
 PORT=3000

--- a/docker/.env.vagrant.production
+++ b/docker/.env.vagrant.production
@@ -1,7 +1,6 @@
 NEXT_PUBLIC_BASE_PATH="/open-terms-archive"
 
 # Automatically create Github issue on contribution
-GITHUB_REPO=ambanum/test-repo
 GITHUB_LABEL_ADD=add-document
 
 PORT=3000

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -12,11 +12,6 @@
 		<priority>0.80</priority>
 	</url>
 	<url>
-		<loc>https://opentermsarchive.org/en/contribute</loc>
-		<lastmod>2021-09-13T07:19:56+00:00</lastmod>
-		<priority>0.80</priority>
-	</url>
-	<url>
 		<loc>https://opentermsarchive.org/en/media</loc>
 		<lastmod>2021-09-13T07:19:56+00:00</lastmod>
 		<priority>0.80</priority>
@@ -38,11 +33,6 @@
 	</url>
 	<url>
 		<loc>https://opentermsarchive.org/fr</loc>
-		<lastmod>2021-09-13T07:19:56+00:00</lastmod>
-		<priority>0.64</priority>
-	</url>
-	<url>
-		<loc>https://opentermsarchive.org/fr/contribute</loc>
 		<lastmod>2021-09-13T07:19:56+00:00</lastmod>
 		<priority>0.64</priority>
 	</url>

--- a/src/modules/Common/containers/Layout.tsx
+++ b/src/modules/Common/containers/Layout.tsx
@@ -118,9 +118,6 @@ const Layout = ({
                   <Link href="/">{t('footer:link.home')}</Link>
                 </li>
                 <li>
-                  <Link href={'/contribute'}>{t('footer:link.contribute')}</Link>
-                </li>
-                <li>
                   <Link href={'/case-studies'}>{t('footer:link.case-studies')}</Link>
                 </li>
                 <li>

--- a/src/modules/Contribute/api/services/index.ts
+++ b/src/modules/Contribute/api/services/index.ts
@@ -92,64 +92,65 @@ const get =
     }
   };
 
-const saveOnLocal = (data: string) => async (_: NextApiRequest, res: NextApiResponse<any>) => {
-  try {
-    let json = JSON.parse(data);
+const saveOnLocal =
+  (data: string, path: string) => async (_: NextApiRequest, res: NextApiResponse<any>) => {
+    try {
+      let json = JSON.parse(data);
 
-    const documentType = Object.keys(json.documents)[0];
-    const sanitizedName = json.name.replace(/[^\p{L}\.\s\d]/gimu, '');
-    const fullPath = `${process.env.NEXT_PUBLIC_OTA_SERVICES_PATH}/${sanitizedName}.json`;
-    const historyFullPath = `${process.env.NEXT_PUBLIC_OTA_SERVICES_PATH}/${sanitizedName}.history.json`;
+      const documentType = Object.keys(json.documents)[0];
+      const sanitizedName = json.name.replace(/[^\p{L}\.\s\d]/gimu, '');
+      const fullPath = `${path}/${sanitizedName}.json`;
+      const historyFullPath = `${path}/${sanitizedName}.history.json`;
 
-    if (fs.existsSync(fullPath)) {
-      const existingJson = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+      if (fs.existsSync(fullPath)) {
+        const existingJson = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
 
-      if (!fs.existsSync(historyFullPath)) {
-        fs.writeFileSync(historyFullPath, '{}');
+        if (!fs.existsSync(historyFullPath)) {
+          fs.writeFileSync(historyFullPath, '{}');
+        }
+
+        let historyJson = JSON.parse(fs.readFileSync(historyFullPath, 'utf8'));
+
+        const latestCommit = await getLatestCommit({
+          path: `${encodeURIComponent(sanitizedName)}/${encodeURIComponent(documentType)}.md`,
+        });
+
+        const lastCommitDate = latestCommit?.commit?.author.date;
+
+        const newHistoryJson = {
+          ...historyJson,
+          [documentType]: [
+            {
+              ...existingJson.documents[documentType],
+              validUntil: dayjs(lastCommitDate || new Date()).format(),
+            },
+            ...(historyJson[documentType] || []),
+          ],
+        };
+        fs.writeFileSync(historyFullPath, JSON.stringify(newHistoryJson, null, 2));
+
+        json = merge(existingJson, json);
       }
 
-      let historyJson = JSON.parse(fs.readFileSync(historyFullPath, 'utf8'));
+      fs.writeFileSync(fullPath, JSON.stringify(json, null, 2));
 
-      const latestCommit = await getLatestCommit({
-        path: `${encodeURIComponent(sanitizedName)}/${encodeURIComponent(documentType)}.md`,
+      res.json({
+        status: 'ok',
+        message: `File saved`,
+        path: fullPath,
       });
-
-      const lastCommitDate = latestCommit?.commit?.author.date;
-
-      const newHistoryJson = {
-        ...historyJson,
-        [documentType]: [
-          {
-            ...existingJson.documents[documentType],
-            validUntil: dayjs(lastCommitDate || new Date()).format(),
-          },
-          ...(historyJson[documentType] || []),
-        ],
-      };
-      fs.writeFileSync(historyFullPath, JSON.stringify(newHistoryJson, null, 2));
-
-      json = merge(existingJson, json);
+    } catch (e: any) {
+      res.statusCode = HttpStatusCode.METHOD_FAILURE;
+      res.json({
+        status: 'ko',
+        message: 'Could not download url',
+        error: e.toString(),
+      });
+      return res;
     }
 
-    fs.writeFileSync(fullPath, JSON.stringify(json, null, 2));
-
-    res.json({
-      status: 'ok',
-      message: `File saved`,
-      path: fullPath,
-    });
-  } catch (e: any) {
-    res.statusCode = HttpStatusCode.METHOD_FAILURE;
-    res.json({
-      status: 'ko',
-      message: 'Could not download url',
-      error: e.toString(),
-    });
     return res;
-  }
-
-  return res;
-};
+  };
 
 const addNewService =
   (body: any) => async (_: NextApiRequest, res: NextApiResponse<PostContributeServiceResponse>) => {
@@ -178,8 +179,8 @@ const services = async (req: NextApiRequest, res: NextApiResponse) => {
     return addNewService(body)(req, res);
   }
 
-  if (req.method === 'POST' && req?.body?.data) {
-    return saveOnLocal(req?.body?.data as string)(req, res);
+  if (req.method === 'POST' && body?.data) {
+    return saveOnLocal(body?.data as string, body?.path as string)(req, res);
   }
 
   res.statusCode = HttpStatusCode.FORBIDDEN;

--- a/src/modules/Contribute/api/services/index.ts
+++ b/src/modules/Contribute/api/services/index.ts
@@ -154,6 +154,7 @@ const saveOnLocal = (data: string) => async (_: NextApiRequest, res: NextApiResp
 const addNewService =
   (body: any) => async (_: NextApiRequest, res: NextApiResponse<PostContributeServiceResponse>) => {
     const service: any = await addService({
+      destination: body?.destination,
       name: body?.name,
       documentType: body?.documentType,
       json: body?.json,

--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -39,9 +39,7 @@ You will need to create the following file in the root of the project: \`service
 
   let existingIssue = await searchIssue({
     ...commonParams,
-    // baseUrl should be the way to go but it goes with a 404 using octokit
-    // baseUrl: `https://api.github.com/${GITHUB_REPO}`,
-    q: `is:issue "${issueTitle}"`,
+    title: issueTitle,
   });
 
   if (existingIssue) {

--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -1,27 +1,28 @@
 import { addCommentToIssue, createIssue, searchIssue } from 'modules/Github/api';
 
-const [GITHUB_OTA_OWNER, GITHUB_OTA_REPO] = (process.env.GITHUB_REPO || '')?.split('/');
-
-const commonParams = {
-  owner: GITHUB_OTA_OWNER,
-  repo: GITHUB_OTA_REPO,
-  accept: 'application/vnd.github.v3+json',
-};
-
 export const addService = async ({
+  destination,
   name,
   documentType,
   json,
   url,
 }: {
+  destination: string;
   name: string;
   documentType: string;
   json: any;
   url: string;
 }) => {
-  if (!process.env.GITHUB_REPO) {
+  if (!destination) {
     return {};
   }
+  const [githubOrganization, githubRepository] = (destination || '')?.split('/');
+
+  const commonParams = {
+    owner: githubOrganization,
+    repo: githubRepository,
+    accept: 'application/vnd.github.v3+json',
+  };
 
   const issueTitle = `Add ${name} - ${documentType}`;
   const issueBodyCommon = `
@@ -36,7 +37,6 @@ ${JSON.stringify(json, null, 2)}
 You will need to create the following file in the root of the project: \`services/${name}.json\`
 
 `;
-
   let existingIssue = await searchIssue({
     ...commonParams,
     title: issueTitle,

--- a/src/modules/Contribute/managers/ServiceManager.ts
+++ b/src/modules/Contribute/managers/ServiceManager.ts
@@ -61,7 +61,7 @@ New service addition requested through the contribution tool
 
 ${issueBodyCommon}
 `,
-      labels: [process.env.GITHUB_REPO || 'add'],
+      labels: [process.env.GITHUB_LABEL_ADD || 'add'],
     });
   }
 

--- a/src/modules/Contribute/pages/home.tsx
+++ b/src/modules/Contribute/pages/home.tsx
@@ -13,14 +13,15 @@ import { useTranslation } from 'next-i18next';
 const ContributeHomePage = () => {
   const { t } = useTranslation();
   const router = useRouter();
+  const destination = router.query?.destination;
 
   useEvent('touchstart', () => {
-    router.push('/contribute/sorry');
+    router.push(`/contribute/sorry?destination=${destination}`);
   });
 
   const onSubmit: SearchProps['onSearchSubmit'] = async (url) => {
     try {
-      router.push(`/contribute/service?url=${encodeURIComponent(url)}`);
+      router.push(`/contribute/service?destination=${destination}&url=${encodeURIComponent(url)}`);
     } catch (e) {
       console.error(e);
     }

--- a/src/modules/Contribute/pages/home.tsx
+++ b/src/modules/Contribute/pages/home.tsx
@@ -13,8 +13,10 @@ import { useTranslation } from 'next-i18next';
 const ContributeHomePage = () => {
   const { t } = useTranslation();
   const router = useRouter();
-  const { localPath, destination } = router.query;
-  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}`;
+  const { localPath, destination, versionsRepo } = router.query;
+  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}${
+    versionsRepo ? `&versionsRepo=${versionsRepo}` : ''
+  }`;
 
   useEvent('touchstart', () => {
     router.push(`/contribute/sorry?${commonUrlParams}`);

--- a/src/modules/Contribute/pages/home.tsx
+++ b/src/modules/Contribute/pages/home.tsx
@@ -39,24 +39,29 @@ const ContributeHomePage = () => {
       <Container paddingY={false}>
         <Container gridCols="12" gridGutters="11" flex={true} paddingX={false}>
           <Column width={100}>
-            <Breadcrumb
-              items={[
-                {
-                  name: t('contribute:breadcrumb.home_page.name'),
-                  url: 'https://opentermsarchive.org',
-                },
-                { name: t('contribute/home:title') },
-              ]}
-            />
-            <TextContent>
-              <p>{t('contribute/home:content.p1')}</p>
-            </TextContent>
-            <Search
-              label={t('contribute/home:search.label')}
-              buttonLabel={t('contribute/home:search.button')}
-              placeholder="https://www.amazon.com/gp/help/customer/display.html?nodeId=13819201"
-              onSearchSubmit={onSubmit}
-            />
+            {!destination && <TextContent>{t('contribute/home:no-destination')}</TextContent>}
+            {destination && (
+              <>
+                <Breadcrumb
+                  items={[
+                    {
+                      name: t('contribute:breadcrumb.home_page.name'),
+                      url: 'https://opentermsarchive.org',
+                    },
+                    { name: t('contribute/home:title') },
+                  ]}
+                />
+                <TextContent>
+                  <p>{t('contribute/home:content.p1')}</p>
+                </TextContent>
+                <Search
+                  label={t('contribute/home:search.label')}
+                  buttonLabel={t('contribute/home:search.button')}
+                  placeholder="https://www.amazon.com/gp/help/customer/display.html?nodeId=13819201"
+                  onSearchSubmit={onSubmit}
+                />
+              </>
+            )}
           </Column>
         </Container>
       </Container>

--- a/src/modules/Contribute/pages/home.tsx
+++ b/src/modules/Contribute/pages/home.tsx
@@ -13,15 +13,16 @@ import { useTranslation } from 'next-i18next';
 const ContributeHomePage = () => {
   const { t } = useTranslation();
   const router = useRouter();
-  const destination = router.query?.destination;
+  const { localPath, destination } = router.query;
+  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}`;
 
   useEvent('touchstart', () => {
-    router.push(`/contribute/sorry?destination=${destination}`);
+    router.push(`/contribute/sorry?${commonUrlParams}`);
   });
 
   const onSubmit: SearchProps['onSearchSubmit'] = async (url) => {
     try {
-      router.push(`/contribute/service?destination=${destination}&url=${encodeURIComponent(url)}`);
+      router.push(`/contribute/service?${commonUrlParams}&url=${encodeURIComponent(url)}`);
     } catch (e) {
       console.error(e);
     }

--- a/src/modules/Contribute/pages/service.tsx
+++ b/src/modules/Contribute/pages/service.tsx
@@ -25,11 +25,9 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
   const router = useRouter();
   const { t } = useTranslation();
   const { notify } = useNotifier();
-  useEvent('touchstart', () => {
-    router.push('/contribute/sorry');
-  });
   const {
     queryParams: {
+      destination,
       url,
       step: initialStep,
       selectedCss: initialSelectedCss,
@@ -40,6 +38,10 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     },
     pushQueryParam,
   } = useUrl();
+
+  useEvent('touchstart', () => {
+    router.push(`/contribute/sorry?destination=${destination}`);
+  });
 
   const json = {
     name: initialName || '???',
@@ -141,6 +143,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
       const {
         data: { url },
       } = await api.post<PostContributeServiceResponse>('/api/contribute/services', {
+        destination,
         json,
         name: initialName,
         documentType: initialDocumentType,
@@ -162,11 +165,11 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
           `mailto:${EMAIL_SUPPORT}?subject=${subject}&body=${encodeURIComponent(body)}`,
           '_blank'
         );
-        router.push(`/contribute/thanks?email=true`);
+        router.push(`/contribute/thanks?destination=${destination}&email=true`);
         return;
       }
-      router.push(`/contribute/thanks?url=${encodeURIComponent(url)}`);
-    } catch (e) {
+      router.push(`/contribute/thanks?destination=${destination}&url=${encodeURIComponent(url)}`);
+    } catch (e: any) {
       notify('error', e.toString());
       toggleLoading(false);
     }
@@ -191,7 +194,7 @@ Thank you very much`;
       '_blank'
     );
 
-    router.push('/contribute/thanks');
+    router.push(`/contribute/thanks?destination=${destination}`);
   };
 
   const saveOnLocal = async () => {
@@ -218,7 +221,7 @@ Thank you very much`;
               <LinkIcon
                 className={s.backButton}
                 iconColor="var(--colorBlack400)"
-                href="/contribute"
+                href={`/contribute?destination=${destination}`}
                 direction="left"
                 small={true}
               >
@@ -252,7 +255,7 @@ Thank you very much`;
               <LinkIcon
                 className={s.backButton}
                 iconColor="var(--colorBlack400)"
-                href="/contribute"
+                href={`/contribute?destination=${destination}`}
                 direction="left"
                 small={true}
               >

--- a/src/modules/Contribute/pages/service.tsx
+++ b/src/modules/Contribute/pages/service.tsx
@@ -29,6 +29,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     queryParams: {
       destination,
       localPath,
+      versionsRepo,
       url,
       step: initialStep,
       selectedCss: initialSelectedCss,
@@ -39,8 +40,9 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     },
     pushQueryParam,
   } = useUrl();
-  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}`;
-
+  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}${
+    versionsRepo ? `&versionsRepo=${versionsRepo}` : ''
+  }`;
   useEvent('touchstart', () => {
     router.push(`/contribute/sorry?${commonUrlParams}`);
   });
@@ -201,6 +203,7 @@ Thank you very much`;
 
   const saveOnLocal = async () => {
     await api.post('/api/contribute/services', {
+      versionsRepo,
       path: localPath,
       data: JSON.stringify(json),
     });

--- a/src/modules/Contribute/pages/service.tsx
+++ b/src/modules/Contribute/pages/service.tsx
@@ -39,9 +39,10 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     },
     pushQueryParam,
   } = useUrl();
+  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}`;
 
   useEvent('touchstart', () => {
-    router.push(`/contribute/sorry?destination=${destination}`);
+    router.push(`/contribute/sorry?${commonUrlParams}`);
   });
 
   const json = {
@@ -166,10 +167,10 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
           `mailto:${EMAIL_SUPPORT}?subject=${subject}&body=${encodeURIComponent(body)}`,
           '_blank'
         );
-        router.push(`/contribute/thanks?destination=${destination}&email=true`);
+        router.push(`/contribute/thanks?${commonUrlParams}&email=true`);
         return;
       }
-      router.push(`/contribute/thanks?destination=${destination}&url=${encodeURIComponent(url)}`);
+      router.push(`/contribute/thanks?${commonUrlParams}&url=${encodeURIComponent(url)}`);
     } catch (e: any) {
       notify('error', e.toString());
       toggleLoading(false);
@@ -195,7 +196,7 @@ Thank you very much`;
       '_blank'
     );
 
-    router.push(`/contribute/thanks?destination=${destination}`);
+    router.push(`/contribute/thanks?${commonUrlParams}`);
   };
 
   const saveOnLocal = async () => {
@@ -222,7 +223,7 @@ Thank you very much`;
               <LinkIcon
                 className={s.backButton}
                 iconColor="var(--colorBlack400)"
-                href={`/contribute?destination=${destination}`}
+                href={`/contribute?${commonUrlParams}`}
                 direction="left"
                 small={true}
               >
@@ -256,7 +257,7 @@ Thank you very much`;
               <LinkIcon
                 className={s.backButton}
                 iconColor="var(--colorBlack400)"
-                href={`/contribute?destination=${destination}`}
+                href={`/contribute?${commonUrlParams}`}
                 direction="left"
                 small={true}
               >

--- a/src/modules/Contribute/pages/service.tsx
+++ b/src/modules/Contribute/pages/service.tsx
@@ -47,6 +47,11 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
     router.push(`/contribute/sorry?${commonUrlParams}`);
   });
 
+  if (!destination && typeof window !== 'undefined') {
+    // This is here as previously created issues still point at a url that has no `destination` param
+    pushQueryParam('destination')('OpenTermsArchive/services-all');
+  }
+
   const json = {
     name: initialName || '???',
     documents: {

--- a/src/modules/Contribute/pages/service.tsx
+++ b/src/modules/Contribute/pages/service.tsx
@@ -28,6 +28,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
   const {
     queryParams: {
       destination,
+      localPath,
       url,
       step: initialStep,
       selectedCss: initialSelectedCss,
@@ -199,7 +200,7 @@ Thank you very much`;
 
   const saveOnLocal = async () => {
     await api.post('/api/contribute/services', {
-      path: process.env.NEXT_PUBLIC_OTA_SERVICES_PATH,
+      path: localPath,
       data: JSON.stringify(json),
     });
   };
@@ -355,12 +356,12 @@ Thank you very much`;
                   <>
                     <pre className={classNames(s.json)}>{JSON.stringify(json, null, 2)}</pre>
                     <div className={classNames(s.expertButtons)}>
-                      {process.env.NEXT_PUBLIC_OTA_SERVICES_PATH && (
+                      {localPath && (
                         <Button
                           onClick={saveOnLocal}
                           size="sm"
                           type="secondary"
-                          title={`Save on ${process.env.NEXT_PUBLIC_OTA_SERVICES_PATH}`}
+                          title={`Save on ${localPath}`}
                         >
                           {t('contribute/service:expertMode.button.label')}
                         </Button>

--- a/src/modules/Contribute/pages/service.tsx
+++ b/src/modules/Contribute/pages/service.tsx
@@ -162,7 +162,7 @@ const ServicePage = ({ documentTypes }: { documentTypes: string[] }) => {
           `mailto:${EMAIL_SUPPORT}?subject=${subject}&body=${encodeURIComponent(body)}`,
           '_blank'
         );
-        router.push(`/contribute/thanks?email`);
+        router.push(`/contribute/thanks?email=true`);
         return;
       }
       router.push(`/contribute/thanks?url=${encodeURIComponent(url)}`);

--- a/src/modules/Contribute/pages/sorry.tsx
+++ b/src/modules/Contribute/pages/sorry.tsx
@@ -11,9 +11,10 @@ const EMAIL_SUPPORT = 'contact@opentermsarchive.org';
 
 const SorryPage = () => {
   const router = useRouter();
-  const { localPath, destination } = router.query;
-  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}`;
-
+  const { localPath, destination, versionsRepo } = router.query;
+  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}${
+    versionsRepo ? `&versionsRepo=${versionsRepo}` : ''
+  }`;
   const { t } = useTranslation();
   return (
     <Layout title={t('contribute/sorry:seo.title')}>

--- a/src/modules/Contribute/pages/sorry.tsx
+++ b/src/modules/Contribute/pages/sorry.tsx
@@ -1,6 +1,7 @@
 import Breadcrumb from 'components/BreadCrumb';
 import Column from 'modules/Common/components/Column';
 import Container from 'modules/Common/containers/Container';
+import { useRouter } from 'next/router';
 import Hero from 'modules/Common/components/Hero';
 import Layout from 'modules/Common/containers/Layout';
 import React from 'react';
@@ -9,6 +10,7 @@ import { useTranslation } from 'next-i18next';
 const EMAIL_SUPPORT = 'contact@opentermsarchive.org';
 
 const SorryPage = () => {
+  const router = useRouter();
   const { t } = useTranslation();
   return (
     <Layout title={t('contribute/sorry:seo.title')}>
@@ -31,7 +33,10 @@ const SorryPage = () => {
                   name: t('contribute:breadcrumb.home_page.name'),
                   url: 'https://opentermsarchive.org',
                 },
-                { name: t('contribute/home:title'), url: '/contribute' },
+                {
+                  name: t('contribute/home:title'),
+                  url: `/contribute?destination=${router.query?.destination}`,
+                },
                 { name: t('contribute/sorry:title') },
               ]}
             />

--- a/src/modules/Contribute/pages/sorry.tsx
+++ b/src/modules/Contribute/pages/sorry.tsx
@@ -11,6 +11,9 @@ const EMAIL_SUPPORT = 'contact@opentermsarchive.org';
 
 const SorryPage = () => {
   const router = useRouter();
+  const { localPath, destination } = router.query;
+  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}`;
+
   const { t } = useTranslation();
   return (
     <Layout title={t('contribute/sorry:seo.title')}>
@@ -35,7 +38,7 @@ const SorryPage = () => {
                 },
                 {
                   name: t('contribute/home:title'),
-                  url: `/contribute?destination=${router.query?.destination}`,
+                  url: `/contribute?destination=${commonUrlParams}`,
                 },
                 { name: t('contribute/sorry:title') },
               ]}

--- a/src/modules/Github/api/index.ts
+++ b/src/modules/Github/api/index.ts
@@ -1,6 +1,7 @@
 const DOCUMENT_TYPES_URL = 'https://opentermsarchive.org/data/api/list_documentTypes/v1/';
 export const CONTRIBUTORS_URL =
   'https://api.github.com/repos/ambanum/OpenTermsArchive/contributors';
+export const VERSIONS_BASE_URL = 'https://api.github.com/repos/ambanum/OpenTermsArchive-versions';
 export const VERSIONS_CONTRIBUTOR_COMMITS_ACTIVITY =
   'https://api.github.com/repos/ambanum/OpenTermsArchive-versions/stats/contributors';
 export const LAST_VERSIONS_COMMITS =
@@ -168,10 +169,12 @@ export const getLastVersionsCommits = async () => {
   }
 };
 
-export const getLatestCommit = async (params: { path: string }) => {
+export const getLatestCommit = async (params: { repo: string; path: string }) => {
+  const repoUrl = `https://api.github.com/repos/${params.repo}/commits`;
+
   try {
     const { data }: { data: Commits } = await octokit.request(
-      `GET ${LAST_VERSIONS_COMMITS}?path=${params.path}`,
+      `GET ${repoUrl}?path=${params.path}`,
       {
         page: 1,
         per_page: 1,

--- a/src/pages/contribute/thanks.tsx
+++ b/src/pages/contribute/thanks.tsx
@@ -16,7 +16,7 @@ import useUrl from 'hooks/useUrl';
 export default function ThanksPage({ mdxContent }: WithI18nResult) {
   const { t } = useTranslation();
   const {
-    queryParams: { url, email },
+    queryParams: { url, destination, email },
   } = useUrl();
   return (
     <Layout title={t('contribute/thanks:seo.title')} desc={t('contribute/thanks:seo.desc')}>
@@ -34,7 +34,7 @@ export default function ThanksPage({ mdxContent }: WithI18nResult) {
               name: t('contribute:breadcrumb.home_page.name'),
               url: 'https://opentermsarchive.org',
             },
-            { name: t('contribute/home:title'), url: '/contribute' },
+            { name: t('contribute/home:title'), url: `/contribute?destination=${destination}` },
             { name: t('contribute:breadcrumb.thanks.name') },
           ]}
         />
@@ -55,7 +55,7 @@ export default function ThanksPage({ mdxContent }: WithI18nResult) {
       <Container gridCols="9" gridGutters="8" paddingTop={false}>
         <TextContent className="text__center">
           <hr />
-          <Link href="/contribute">
+          <Link href={`/contribute?destination=${destination}`}>
             <Button>{t('contribute/thanks:cta')}</Button>
           </Link>
         </TextContent>

--- a/src/pages/contribute/thanks.tsx
+++ b/src/pages/contribute/thanks.tsx
@@ -16,7 +16,7 @@ import useUrl from 'hooks/useUrl';
 export default function ThanksPage({ mdxContent }: WithI18nResult) {
   const { t } = useTranslation();
   const {
-    queryParams: { url },
+    queryParams: { url, email },
   } = useUrl();
   return (
     <Layout title={t('contribute/thanks:seo.title')} desc={t('contribute/thanks:seo.desc')}>
@@ -40,11 +40,13 @@ export default function ThanksPage({ mdxContent }: WithI18nResult) {
         />
       </Container>
 
-      <Container gridCols="9" gridGutters="8" paddingY={false}>
-        <TextContent>
-          <MDXRemote {...(mdxContent as any)} scope={{ url }} />
-        </TextContent>
-      </Container>
+      {!email && (
+        <Container gridCols="9" gridGutters="8" paddingY={false}>
+          <TextContent>
+            <MDXRemote {...(mdxContent as any)} scope={{ url }} />
+          </TextContent>
+        </Container>
+      )}
 
       <Container gridCols="6" gridGutters="5">
         <Contributors subtitle={t('contribute:contributors.subtitle')} />

--- a/src/pages/contribute/thanks.tsx
+++ b/src/pages/contribute/thanks.tsx
@@ -16,8 +16,11 @@ import useUrl from 'hooks/useUrl';
 export default function ThanksPage({ mdxContent }: WithI18nResult) {
   const { t } = useTranslation();
   const {
-    queryParams: { url, destination, email },
+    queryParams: { url, destination, email, localPath },
   } = useUrl();
+
+  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}`;
+
   return (
     <Layout title={t('contribute/thanks:seo.title')} desc={t('contribute/thanks:seo.desc')}>
       {/* Hero */}
@@ -34,7 +37,7 @@ export default function ThanksPage({ mdxContent }: WithI18nResult) {
               name: t('contribute:breadcrumb.home_page.name'),
               url: 'https://opentermsarchive.org',
             },
-            { name: t('contribute/home:title'), url: `/contribute?destination=${destination}` },
+            { name: t('contribute/home:title'), url: `/contribute?${commonUrlParams}` },
             { name: t('contribute:breadcrumb.thanks.name') },
           ]}
         />
@@ -55,7 +58,7 @@ export default function ThanksPage({ mdxContent }: WithI18nResult) {
       <Container gridCols="9" gridGutters="8" paddingTop={false}>
         <TextContent className="text__center">
           <hr />
-          <Link href={`/contribute?destination=${destination}`}>
+          <Link href={`/contribute?${commonUrlParams}`}>
             <Button>{t('contribute/thanks:cta')}</Button>
           </Link>
         </TextContent>

--- a/src/pages/contribute/thanks.tsx
+++ b/src/pages/contribute/thanks.tsx
@@ -16,10 +16,11 @@ import useUrl from 'hooks/useUrl';
 export default function ThanksPage({ mdxContent }: WithI18nResult) {
   const { t } = useTranslation();
   const {
-    queryParams: { url, destination, email, localPath },
+    queryParams: { url, destination, email, localPath, versionsRepo },
   } = useUrl();
-
-  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}`;
+  const commonUrlParams = `destination=${destination}${localPath ? `&localPath=${localPath}` : ''}${
+    versionsRepo ? `&versionsRepo=${versionsRepo}` : ''
+  }`;
 
   return (
     <Layout title={t('contribute/thanks:seo.title')} desc={t('contribute/thanks:seo.desc')}>

--- a/src/translations/en/contribute/home.json
+++ b/src/translations/en/contribute/home.json
@@ -1,5 +1,6 @@
 {
   "content.p1": "With 3-step process, you can add a document quickly (it should only take you a few minutes)",
+  "no-destination": "No destination is present in the url and you should never end up on this page, please contact us through the footer link for more information.",
   "search.button": "Next",
   "search.label": "First step, please fill the URL to track",
   "seo.desc": "Thanks for helping",

--- a/src/translations/en/footer.json
+++ b/src/translations/en/footer.json
@@ -3,7 +3,6 @@
   "link.case-studies": "Case studies",
   "link.contact": "Contact us",
   "link.contact.title": "Contact us by mail",
-  "link.contribute": "Contribute",
   "link.dashboard": "Dashboard",
   "link.dashboard.title": "A set of activity metrics",
   "link.dataset": "Dataset",

--- a/src/translations/fr/contribute/home.json
+++ b/src/translations/fr/contribute/home.json
@@ -1,5 +1,6 @@
 {
   "content.p1": "Grâce à un processus en trois étapes, vous pouvez ajouter un document rapidement (cela ne devrait vous prendre que quelques minutes).",
+  "no-destination": "Aucune destination n'est présente dans l'url et vous ne devriez jamais aboutir sur cette page, veuillez nous contacter via le lien en bas de page pour plus d'informations.",
   "search.button": "Suivant",
   "search.label": "Première étape, veuillez saisir l'URL à suivre",
   "seo.desc": "Merci pour votre aide",

--- a/src/translations/fr/footer.json
+++ b/src/translations/fr/footer.json
@@ -3,7 +3,6 @@
   "link.case-studies": "Études de cas",
   "link.contact": "Contactez-nous",
   "link.contact.title": "Contactez nous par email",
-  "link.contribute": "Contribuer",
   "link.dashboard": "Tableau de bord",
   "link.dashboard.title": "Des données pour mesurer l'activité",
   "link.dataset": "Jeu de données",


### PR DESCRIPTION
Fixes #92 

In order for the contribution tool to be used on `services-all` and `services-dating` (and maybe more soon) and before it is extracted to a new project, the contribution system can now be configured through url params

**Mandatory**
- `destination`: the repo on which the Github issues will be created

**Optional**
- `localPath`: to save the corresponding JSON file directly in a local folder
- `versionsRepo`: to generate automatically history file based on document latest version (retrieved from Github)


