### PR TITLE
Handle api redirection in code instead of nginx

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,4 +58,12 @@ module.exports = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: '/data/api/:slug*',
+        destination: 'http://51.75.169.235:7011/data/api/:slug*',
+      },
+    ];
+  },
 };


### PR DESCRIPTION
For now this rewrite is done directly in nginx.
Once we move opentermsarchive.org to scalingo, the DNS A record will point on scalingo and thus this nginx config will be useless