### PR TITLE
Use zigzag text image layout

### DIFF
--- a/src/modules/Common/components/Column.module.css
+++ b/src/modules/Common/components/Column.module.css
@@ -70,6 +70,7 @@
 
   &.column__alignXright {
     justify-content: flex-end;
+    text-align: right;
   }
 
   &.column__alignYcenter {
@@ -81,7 +82,7 @@
   }
 
   &:not(:first-child) {
-    margin-left: var(--gridGutterWidth);
+    margin-left: var(--m2XL);
   }
 }
 
@@ -122,6 +123,7 @@
 
     &.column__alignXright {
       justify-content: flex-start;
+      text-align: left;
     }
 
     &.column__mobile__order1 {

--- a/src/pages/homepage.tsx
+++ b/src/pages/homepage.tsx
@@ -33,11 +33,11 @@ const HomePage = () => {
           <h2 className="text__center">{t('homepage:how.title')}</h2>
         </Container>
         <Container gridCols="11" gridGutters="10" flex={true} paddingX={false}>
-          <Column width={50}>
+          <Column width={50} alignX="right">
             <h3>{t('homepage:how.bloc1.title')}</h3>
             <p className="mt__M h3 h3__light">{t('homepage:how.bloc1.desc')}</p>
           </Column>
-          <Column width={50} alignX="right">
+          <Column width={50}>
             <div style={{ maxWidth: '480px' }}>
               <img src="/images/how-it-works/step-1.png" />
             </div>
@@ -47,13 +47,15 @@ const HomePage = () => {
       {/* How it works -  2 step */}
       <Container layout="wide" paddingY={false}>
         <Container gridCols="11" gridGutters="10" flex={true} paddingX={false}>
-          <Column width={50}>
-            <h3>{t('homepage:how.bloc2.title')}</h3>
-            <p className="mt__M h3 h3__light">{t('homepage:how.bloc2.desc')}</p>
-          </Column>
-          <Column width={50} alignX="right">
+          <Column width={50} alignX="right" mobileOrder={2}>
             <div style={{ maxWidth: '480px' }}>
               <img src="/images/how-it-works/step-2.png" />
+            </div>
+          </Column>
+          <Column width={50} mobileOrder={1}>
+            <div>
+              <h3>{t('homepage:how.bloc2.title')}</h3>
+              <p className="mt__M h3 h3__light">{t('homepage:how.bloc2.desc')}</p>
             </div>
           </Column>
         </Container>
@@ -61,11 +63,11 @@ const HomePage = () => {
       {/* How it works -  3 step */}
       <Container layout="wide" paddingY={false}>
         <Container gridCols="11" gridGutters="10" flex={true} paddingX={false}>
-          <Column width={50}>
+          <Column width={50} alignX="right">
             <h3>{t('homepage:how.bloc3.title')}</h3>
             <p className="mt__M h3 h3__light">{t('homepage:how.bloc3.desc')}</p>
           </Column>
-          <Column width={50} alignX="right">
+          <Column width={50}>
             <div style={{ maxWidth: '430px' }}>
               <img src="/images/how-it-works/step-3.png" />
             </div>
@@ -75,20 +77,22 @@ const HomePage = () => {
       {/* How it works -  4 step */}
       <Container layout="wide" paddingTop={false}>
         <Container gridCols="11" gridGutters="10" flex={true} paddingX={false}>
-          <Column width={50}>
-            <h3>{t('homepage:how.bloc4.title')}</h3>
-            <p className="mt__M h3 h3__light">{t('homepage:how.bloc4.desc')}</p>
-            <p className="mt__L">
-              <Link href="https://github.com/ambanum/OpenTermsArchive-versions/releases">
-                <a target="_blank" rel="noopener">
-                  <Button type="secondary">{t('homepage:how.bloc4.cta.label')}</Button>
-                </a>
-              </Link>
-            </p>
-          </Column>
-          <Column width={50} alignX="right" alignY="center">
+          <Column width={50} alignX="right" mobileOrder={2}>
             <div style={{ maxWidth: '350px' }}>
               <img src="/images/how-it-works/step-4.png" />
+            </div>
+          </Column>
+          <Column width={50} mobileOrder={1}>
+            <div>
+              <h3>{t('homepage:how.bloc4.title')}</h3>
+              <p className="mt__M h3 h3__light">{t('homepage:how.bloc4.desc')}</p>
+              <p className="mt__L">
+                <Link href="https://github.com/ambanum/OpenTermsArchive-versions/releases">
+                  <a target="_blank" rel="noopener">
+                    <Button type="secondary">{t('homepage:how.bloc4.cta.label')}</Button>
+                  </a>
+                </Link>
+              </p>
             </div>
           </Column>
         </Container>


### PR DESCRIPTION
This has been on my mind for a long time: i think it would be better to use a zigzag layout on the homepage for the how-to steps.

- in my opinion it's much prettier and this makes the reading more dynamic and enjoyable reading
- it seems to me more standard with what is being done on the web

ℹ️ An [interesting reading](https://www.nngroup.com/articles/zigzag-page-layout/) from the NNgroup about this kind of layout.
 
**Before:**
![Screenshot 2022-09-06 at 15-03-04 Open Terms Archive](https://user-images.githubusercontent.com/364319/188653975-ed29dda7-c681-4809-aaee-9bef02c2d88c.png)

**After:**
![Screenshot 2022-09-06 at 15-54-45 Open Terms Archive](https://user-images.githubusercontent.com/364319/188654013-ee8363ac-f708-463d-ab1f-e5466c4d16aa.png)
