### PR TITLE
Move media link to sub footer nav and remove dataset link

### DIFF
--- a/locales/en/footer.json
+++ b/locales/en/footer.json
@@ -5,8 +5,6 @@
   "link.case-studies": "Case studies",
   "link.contact": "Contact us",
   "link.contact.title": "Contact us by mail",
-  "link.dataset": "Dataset",
-  "link.dataset.title": "Download the dataset",
   "link.github": "Source code",
   "link.github.title": "Go to the GitHub repository",
   "link.home": "Home",

--- a/locales/fr/footer.json
+++ b/locales/fr/footer.json
@@ -5,8 +5,6 @@
   "link.case-studies": "Études de cas",
   "link.contact": "Contactez-nous",
   "link.contact.title": "Contactez nous par email",
-  "link.dataset": "Jeu de données",
-  "link.dataset.title": "Télécharger un jeu de données",
   "link.github": "Code source",
   "link.github.title": "Voir le code source",
   "link.home": "Accueil",

--- a/src/modules/Common/containers/Layout.tsx
+++ b/src/modules/Common/containers/Layout.tsx
@@ -119,9 +119,6 @@ const Layout = ({
                 <li>
                   <Link href={'/about'}>{t('footer:link.about')}</Link>
                 </li>
-                <li>
-                  <Link href={'/media'}>{t('footer:link.media')}</Link>
-                </li>
               </ul>
               <ul>
                 <li>
@@ -160,14 +157,7 @@ const Layout = ({
                   </Link>
                 </li>
                 <li>
-                  <Link
-                    href="https://github.com/OpenTermsArchive/contrib-versions/releases"
-                    title={t('footer:link.dataset.title')}
-                    target="_blank"
-                    rel="noopener"
-                  >
-                    {t('footer:link.dataset')}
-                  </Link>
+                  <Link href="/media">{t('footer:link.media')}</Link>
                 </li>
                 <li>
                   <Link


### PR DESCRIPTION
According to [this comment](https://github.com/OpenTermsArchive/docs/pull/16#discussion_r1041926992) and to have the same footer on the site and on the doc.