### PR TITLE
Hide related collections when empty

### DIFF
--- a/themes/opentermsarchive/layouts/partials/related-collections.html
+++ b/themes/opentermsarchive/layouts/partials/related-collections.html
@@ -1,28 +1,35 @@
 {{ $size := default "87" .size }}
-{{ $collectionsIDs := slice }}
+{{ $allCollectionsIDs := slice }}
 {{ range site.Data.collections }}
-  {{ $collectionsIDs = $collectionsIDs | append (index . "id") }}
+  {{ $allCollectionsIDs = $allCollectionsIDs | append (index . "id") }}
 {{ end }}
 
 {{ range $.relatedCollectionsIDs }}
-  {{ if not (in $collectionsIDs .) }}
+  {{ if not (in $allCollectionsIDs .) }}
     {{ warnf "Related collection %q not found" . }}
   {{ end }}
 {{ end }}
 
-<div class="container {{ $.class }}" id="related-collections-{{ .Params.id }}">
-  <div class="container container--{{ $size }} container--has-no-padding-y">
-    <div class="collections cardlist">
-      <div class="cardlist__header">
-        <h3 class="cardlist__title">{{ i18n "impact.related_collections" }}</h3>
-      </div>
-      <div class="cardlist__items">
-        {{ range where site.RegularPages "Section" "collections" }}
-          {{ if in $.relatedCollectionsIDs .Params.id }}
+{{ $matchingCollections := slice }}
+{{ range where site.RegularPages "Section" "collections" }}
+  {{ if in $.relatedCollectionsIDs .Params.id }}
+    {{ $matchingCollections = $matchingCollections | append . }}
+  {{ end }}
+{{ end }}
+
+{{ if $matchingCollections }}
+  <div class="container {{ $.class }}" id="related-collections-{{ .Params.id }}">
+    <div class="container container--{{ $size }} container--has-no-padding-y">
+      <div class="collections cardlist">
+        <div class="cardlist__header">
+          <h3 class="cardlist__title">{{ i18n "impact.related_collections" }}</h3>
+        </div>
+        <div class="cardlist__items">
+          {{ range $matchingCollections }}
             {{ partial "collection-card.html" (dict "context" .) }}
           {{ end }}
-        {{ end }}
+        </div>
       </div>
     </div>
   </div>
-</div>
+{{ end }}


### PR DESCRIPTION
Prevent to display an empty related collection section.

Before: https://opentermsarchive.org/en/memos/tiktok-expands-data-collection-in-europe-the-united-kingdom-and-switzerland/
After: https://deploy-preview-478--open-terms-archive-website.netlify.app/en/memos/tiktok-expands-data-collection-in-europe-the-united-kingdom-and-switzerland/

<img width="950" height="478" alt="image" src="https://github.com/user-attachments/assets/6335b0a6-b0f8-42a2-ad05-39648180276f" />
