### PR TITLE
Prevent build failure on network timeout

### DIFF
--- a/themes/opentermsarchive/layouts/shortcodes/embed.html
+++ b/themes/opentermsarchive/layouts/shortcodes/embed.html
@@ -14,12 +14,12 @@
 
 {{ with try (resources.GetRemote $src) }}
   {{ with .Err }}
-    {{ errorf "%s" . }}
+    {{ warnf "%s" . }}
   {{ else with .Value }}
     <div class="embed__wrapper"style="padding-top: {{ $ratio }};">
       <embed src="{{ .RelPermalink }}" type="{{ $type }}" {{ with $title }}title="{{ . }}"{{ end }}>
     </div>
   {{ else }}
-    {{ errorf "Unable to get remote resource %q" . }}
+    {{ warnf "Unable to get remote resource %q" . }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
This change replaces errorf with warnf to prevent the build from failing, should fix https://github.com/OpenTermsArchive/opentermsarchive.org/actions/runs/20234861498/job/58090290482