### PR TITLE
Add feed endpoints

### DIFF
--- a/content/collections/_content.gotmpl
+++ b/content/collections/_content.gotmpl
@@ -38,6 +38,7 @@
     "totalTerms" .totalTerms
     "engineVersion" .engineVersion
     "federated" .federated
+    "hasFeed" .hasFeed
   }}
   {{ $page := dict
     "params" $params

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -102,6 +102,7 @@ collections:
     details: View details
     download: Download dataset
     endpoint: Access API
+    feed: Feed abonnieren
     reuses: See all reuses
   volunteer_contributors: Volunteer contributors
   new:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -96,6 +96,7 @@ collections:
     details: View details
     download: Download dataset
     endpoint: Access API
+    feed: Subscribe to feed
     reuses: See all reuses
   volunteer_contributors: Volunteer contributors
   new:

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -102,6 +102,7 @@ collections:
     details: Voir les détails
     download: Télécharger le jeu de données
     endpoint: Accéder à l'API
+    feed: S'abonner au flux
     reuses: Voir toutes les réutilisations
   volunteer_contributors: Contributeurs bénévoles
   new:

--- a/scripts/fetch-collections.js
+++ b/scripts/fetch-collections.js
@@ -21,12 +21,22 @@ async function fetchCollections() {
 
         const data = await response.json();
 
+        const feedEndpoint = new URL('feed', collection.endpoint).href;
+        let hasFeed = false;
+        try {
+          const feedResponse = await fetch(feedEndpoint, { method: 'HEAD', timeout: 5000, referrer: 'https://opentermsarchive.org' });
+          hasFeed = feedResponse.ok;
+        } catch {
+          hasFeed = false;
+        }
+
         console.log(`✅ Successfully fetched ${collection.name}`);
 
         return {
           ...data,
           endpoint: collection.endpoint,
           federated: collection.federated,
+          hasFeed,
         };
       } catch (error) {
         console.warn(`❌ Failed to fetch ${collection.name} with the following error message: ${error.message}`);

--- a/themes/opentermsarchive/assets/js/icons.js
+++ b/themes/opentermsarchive/assets/js/icons.js
@@ -36,6 +36,7 @@ import {
   Gavel,
   Newspaper,
   Sparkles,
+  Rss,
   createIcons,
 } from 'lucide';
 
@@ -78,6 +79,7 @@ createIcons({
     Gavel,
     Newspaper,
     Sparkles,
+    Rss,
   },
   attrs: { 'aria-hidden': true },
 });

--- a/themes/opentermsarchive/layouts/collections/single.html
+++ b/themes/opentermsarchive/layouts/collections/single.html
@@ -66,6 +66,14 @@
                 </a>
               </li>
             {{ end }}
+            {{ if .Params.hasFeed }}
+              <li>
+                <a class="button button--secondary" href="{{ printf "%sfeed" .Params.endpoint }}" target="_blank" rel="noopener">
+                  {{ i18n "collections.cta.feed" }}
+                  <i class="icon ml--2xs" data-lucide="rss"></i>
+                </a>
+              </li>
+            {{ end }}
           </ul>
         </div>
       </div>

--- a/themes/opentermsarchive/layouts/partials/head.html
+++ b/themes/opentermsarchive/layouts/partials/head.html
@@ -8,6 +8,9 @@
   <link rel="alternate" type="{{ .MediaType.Type }}" href="{{ .Permalink }}" title="Memos">
     {{- end }}
   {{- end }}
+  {{- if .Params.hasFeed }}
+  <link rel="alternate" type="application/atom+xml" href="{{ printf "%sfeed" .Params.endpoint }}" title="{{ .Params.name }}">
+  {{- end }}
   {{ $styles := resources.Get "css/loader.css" | toCSS | postCSS (dict "config" "./assets/css/postcss.config.js" "inlineImports" true) }}
   {{ if hugo.IsProduction }}{{ $styles = $styles | minify | fingerprint | resources.PostProcess }}{{ end }}
   <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">


### PR DESCRIPTION
This pull request detect whether each collection's API exposes an Atom feed endpoint at build time via a request, and propagate a `hasFeed` flag to Hugo collection pages. When a feed is available, add an Atom autodiscovery `<link>` in the page head and a "Subscribe to feed" button in the collection header.

Should be merged after https://github.com/OpenTermsArchive/engine/pull/1242 and deploying on demo collection.
