### PR TITLE
Update About Page [EN]

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -52,7 +52,9 @@ about:
   funders:
     title: Funders
     subtitle: Compensate the time of the Core Team and pay for the technical infrastructure.
-    details: This project was in part [funded](https://nlnet.nl/project/TOSDR-OTA/) through the [NGI0 Entrust](https://nlnet.nl/entrust) Fund, a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://www.ngi.eu/) programme, under the aegis of DG Communications Networks, Content and Technology under grant agreement N°101069594.
+    details: | 
+      This project has been [funded](https://nlnet.nl/project/TOSDR-OTA/) in part through the [NGI0 Entrust](https://nlnet.nl/entrust) Fund, a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://www.ngi.eu/) programme, under the aegis of DG Communications Networks, Content and Technology under grant agreement N°101069594.
+      From January 2020 to January 2026, Open Terms Archive was incubated by the French ambassador for digital affairs, who provided legal funding and political sponsorship.
   contributors:
     title: Contributors
     subtitle: Volunteer time and effort to improve the software, data, documentation, outreach or any other form of action that serves Open Terms Archive’s [impact model]({{ .impactLink }}).

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -49,9 +49,6 @@ about:
   analysts:
     title: Analysts
     subtitle: Analyze terms changes, spot important ones and make them understandable through memos and reports.
-  incubator:
-    title: Incubator
-    subtitle: Provides legal hosting and political sponsorship.
   funders:
     title: Funders
     subtitle: Compensate the time of the Core Team and pay for the technical infrastructure.

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -43,13 +43,11 @@ about:
   analysts:
     title: Analysts
     subtitle: Analyze terms changes, spot important ones and make them understandable through memos and reports.
-  incubator:
-    title: Incubator
-    subtitle: Provides legal hosting and political sponsorship.
   funders:
     title: Funders
     subtitle: Compensate the time of the Core Team and pay for the technical infrastructure.
-    details: This project was in part [funded](https://nlnet.nl/project/TOSDR-OTA/) through the [NGI0 Entrust](https://nlnet.nl/entrust) Fund, a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://www.ngi.eu/) programme, under the aegis of DG Communications Networks, Content and Technology under grant agreement N°101069594.
+    details: This project has been [funded](https://nlnet.nl/project/TOSDR-OTA/) in part through the [NGI0 Entrust](https://nlnet.nl/entrust) Fund, a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://www.ngi.eu/) programme, under the aegis of DG Communications Networks, Content and Technology under grant agreement N°101069594.  
+    From January 2020 to January 2026, Open Terms Archive was incubated by the French ambassador for digital affairs, who provided legal funding and political sponsorship.
   contributors:
     title: Contributors
     subtitle: Volunteer time and effort to improve the software, data, documentation, outreach or any other form of action that serves Open Terms Archive’s [impact model]({{ .impactLink }}).

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -46,8 +46,9 @@ about:
   funders:
     title: Funders
     subtitle: Compensate the time of the Core Team and pay for the technical infrastructure.
-    details: This project has been [funded](https://nlnet.nl/project/TOSDR-OTA/) in part through the [NGI0 Entrust](https://nlnet.nl/entrust) Fund, a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://www.ngi.eu/) programme, under the aegis of DG Communications Networks, Content and Technology under grant agreement N°101069594.  
-    From January 2020 to January 2026, Open Terms Archive was incubated by the French ambassador for digital affairs, who provided legal funding and political sponsorship.
+    details: | 
+      This project has been [funded](https://nlnet.nl/project/TOSDR-OTA/) in part through the [NGI0 Entrust](https://nlnet.nl/entrust) Fund, a fund established by [NLnet](https://nlnet.nl/) with financial support from the European Commission's [Next Generation Internet](https://www.ngi.eu/) programme, under the aegis of DG Communications Networks, Content and Technology under grant agreement N°101069594.
+      From January 2020 to January 2026, Open Terms Archive was incubated by the French ambassador for digital affairs, who provided legal funding and political sponsorship.
   contributors:
     title: Contributors
     subtitle: Volunteer time and effort to improve the software, data, documentation, outreach or any other form of action that serves Open Terms Archive’s [impact model]({{ .impactLink }}).

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -49,9 +49,6 @@ about:
   analysts:
     title: Analystes
     subtitle: Analysent les changements dans les conditions, repèrent les importants, et les rendent lisibles en rédigeant des mémos et rapports.
-  incubator:
-    title: Incubateur
-    subtitle: Fournit la structure légale et le soutien politique.
   funders:
     title: Financeurs
     subtitle: Indemnisent le temps de l'équipe cœur et financent l'infrastructure technique.

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -52,7 +52,9 @@ about:
   funders:
     title: Financeurs
     subtitle: Indemnisent le temps de l'équipe cœur et financent l'infrastructure technique.
-    details: Ce projet a été en partie [financé](https://nlnet.nl/project/TOSDR-OTA/) par le fonds [NGI0 Entrust](https://nlnet.nl/entrust), un fonds établi par [NLnet](https://nlnet.nl/) avec le soutien financier du programme [Next Generation Internet](https://www.ngi.eu/) de la Commission européenne, sous l'égide de la DG Réseaux de communication, contenu et technologies dans le cadre de la convention de subvention N°101069594.
+    details: | 
+      Ce projet a été en partie [financé](https://nlnet.nl/project/TOSDR-OTA/) par le fonds [NGI0 Entrust](https://nlnet.nl/entrust), un fonds établi par [NLnet](https://nlnet.nl/) avec le soutien financier du programme [Next Generation Internet](https://www.ngi.eu/) de la Commission européenne, sous l'égide de la DG Réseaux de communication, contenu et technologies dans le cadre de la convention de subvention N°101069594.
+      De janvier 2020 à janvier 2026, Open Terms Archive a bénéficié du soutien de l'Ambassadeur pour le numérique, qui lui a apporté un financement et un soutien politique.
   contributors:
     title: Contributeurs
     subtitle: Offrent du temps bénévole pour améliorer le logiciel, les données, la documentation, la visibilité ou toute autre forme d'action qui contribue au [modèle d'impact]({{ .impactLink }}) d'Open Terms Archive.

--- a/themes/opentermsarchive/layouts/_default/about.html
+++ b/themes/opentermsarchive/layouts/_default/about.html
@@ -14,21 +14,6 @@
         {{ .Content }}
         <hr>
         <div>
-          <h3>{{ i18n "about.incubator.title" }}</h3>
-          <p>{{ i18n "about.incubator.subtitle" }}</p>
-          <div class="thumbgallery mb--2xl">
-            <div class="thumbgallery__items thumbgallery__items--has-no-margin-top">
-              <a href="https://disinfo.quaidorsay.fr" target="_blank" rel="noopener" aria-label="{{ i18n "about.incubator.subtitle" }}">
-                <div class="thumbgallery__item">
-                  {{ with $ambassadeurFrancaisPourLeNumerique }}
-                    <img src="{{ .RelPermalink }}" width="158" height="80">
-                  {{ end }}
-                </div>
-              </a>
-            </div>
-          </div>
-        </div>
-        <div>
           <h3>{{ i18n "about.funders.title" }}</h3>
           <p>{{ i18n "about.funders.subtitle" }}</p>
           <div class="thumbgallery thumbgalery--is-small mb--2xl">


### PR DESCRIPTION
Update incubator and funder descriptions to align with current situation (French MEAE exit, ongoing NLNet Funds, etc.)

I'd also propose moving the "Funders" section to the bottom of the page, after team member and contributor presentations, but I don't know how to do that.